### PR TITLE
Add support for DNS NS queries

### DIFF
--- a/agent/Makefile
+++ b/agent/Makefile
@@ -34,7 +34,7 @@ unit-test: $(GODEP)
 	$(GODEP) go test
 
 acceptance-test: $(GODEP) $(AGENT_BIN) $(CONSUL_BIN)
-	$(GODEP) go test -tags acceptance
+	$(GODEP) go test -tags acceptance -run TestAgent
 
 release: $(AGENT_TAR)
 	curl -X POST --data-binary @$< $(AGENT_DST)/$<

--- a/agent/consul.go
+++ b/agent/consul.go
@@ -68,7 +68,6 @@ func (s *consulStore) getInstances(info info) (instances, error) {
 
 		if isEnv && isService {
 			is = append(is, &instance{
-				info: info,
 				host: e.Node.Node,
 				ip:   ip,
 				port: uint16(e.Service.Port),

--- a/agent/consul.go
+++ b/agent/consul.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"net"
+	"strings"
 
 	"github.com/hashicorp/consul/api"
 	consul "github.com/hashicorp/consul/consul/structs"
@@ -29,7 +30,7 @@ func (s *consulStore) getInstances(info info) (instances, error) {
 			Datacenter: info.zone,
 		}
 
-		is = []*instance{}
+		is = instances{}
 	)
 
 	// As the default we only retrieve healthy instances. Returning different
@@ -67,7 +68,7 @@ func (s *consulStore) getInstances(info info) (instances, error) {
 		}
 
 		if isEnv && isService {
-			is = append(is, &instance{
+			is = append(is, instance{
 				host: e.Node.Node,
 				ip:   ip,
 				port: uint16(e.Service.Port),
@@ -76,6 +77,23 @@ func (s *consulStore) getInstances(info info) (instances, error) {
 	}
 
 	return is, nil
+}
+
+func (s *consulStore) getServers(zone string) (instances, error) {
+	members, err := s.client.Agent().Members(true)
+	if err != nil {
+		return nil, newError(errConsulAPI, "%s", err)
+	}
+	srvs := instances{}
+	for _, m := range members {
+		if strings.HasSuffix(m.Name, "."+zone) {
+			srvs = append(srvs, instance{
+				ip:   net.ParseIP(m.Addr),
+				host: strings.TrimSuffix(m.Name, "."+zone),
+			})
+		}
+	}
+	return srvs, nil
 }
 
 func filterEntries(entries []*api.ServiceEntry) []*api.ServiceEntry {

--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -30,42 +30,40 @@ func TestDNSHandler(t *testing.T) {
 		}
 
 		store = &testStore{
-			instances: instances{
-				{
-					info: api,
-					host: "host1",
-					ip:   net.ParseIP("127.0.0.1"),
-					port: uint16(20000),
+			instances: map[info]instances{
+				api: instances{
+					{
+						host: "host1",
+						ip:   net.ParseIP("127.0.0.1"),
+						port: uint16(20000),
+					},
+					{
+						host: "host1",
+						ip:   net.ParseIP("127.0.0.1"),
+						port: uint16(20001),
+					},
+					{
+						host: "host2",
+						ip:   net.ParseIP("127.0.0.2"),
+						port: uint16(20000),
+					},
+					{
+						host: "host2",
+						ip:   net.ParseIP("127.0.0.2"),
+						port: uint16(20003),
+					},
 				},
-				{
-					info: api,
-					host: "host1",
-					ip:   net.ParseIP("127.0.0.1"),
-					port: uint16(20001),
-				},
-				{
-					info: api,
-					host: "host2",
-					ip:   net.ParseIP("127.0.0.2"),
-					port: uint16(20000),
-				},
-				{
-					info: api,
-					host: "host2",
-					ip:   net.ParseIP("127.0.0.2"),
-					port: uint16(20003),
-				},
-				{
-					info: web,
-					host: "host3",
-					ip:   net.ParseIP("127.0.0.3"),
-					port: uint16(21000),
-				},
-				{
-					info: web,
-					host: "host4",
-					ip:   net.ParseIP("127.0.0.4"),
-					port: uint16(21003),
+				web: instances{
+					{
+						host: "host3",
+						ip:   net.ParseIP("127.0.0.3"),
+						port: uint16(21000),
+					},
+					{
+						host: "host4",
+						ip:   net.ParseIP("127.0.0.4"),
+						port: uint16(21003),
+					},
 				},
 			},
 		}

--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -66,6 +66,9 @@ func TestDNSHandler(t *testing.T) {
 					},
 				},
 			},
+			servers: map[string]instances{
+				zone: instances{{host: "foo"}},
+			},
 		}
 
 		h = dnsHandler(store, zone, domain)
@@ -129,6 +132,20 @@ func TestDNSHandler(t *testing.T) {
 			answers:  2,
 		},
 		{
+			question: fmt.Sprintf("%s.%s", zone, domain),
+			qtype:    dns.TypeNS,
+			answers:  1,
+		},
+		{
+			question: fmt.Sprintf("xx.%s", domain),
+			qtype:    dns.TypeNS,
+		},
+		{
+			question: fmt.Sprintf("foo.%s.%s", zone, domain),
+			qtype:    dns.TypeNS,
+			rcode:    dns.RcodeNameError,
+		},
+		{
 			question: fmt.Sprintf("http.web.prod.harpoon.%s.%s", zone, domain),
 			qtype:    dns.TypeAAAA,
 			rcode:    dns.RcodeNotImplemented,
@@ -136,11 +153,6 @@ func TestDNSHandler(t *testing.T) {
 		{
 			question: fmt.Sprintf("http.web.prod.harpoon.%s.%s", zone, domain),
 			qtype:    dns.TypeMX,
-			rcode:    dns.RcodeNotImplemented,
-		},
-		{
-			question: fmt.Sprintf("http.web.prod.harpoon.%s.%s", zone, domain),
-			qtype:    dns.TypeNS,
 			rcode:    dns.RcodeNotImplemented,
 		},
 		{

--- a/agent/helper_test.go
+++ b/agent/helper_test.go
@@ -3,15 +3,15 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/hashicorp/consul/api"
-	"github.com/miekg/dns"
 	"math/rand"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"reflect"
 	"testing"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/miekg/dns"
 )
 
 // brokenStore implements the glimpse.store interface.
@@ -23,22 +23,14 @@ func (s *brokenStore) getInstances(srv info) (instances, error) {
 
 // testStore implements the glimpse.store interface.
 type testStore struct {
-	instances []*instance
+	instances map[info]instances
 }
 
 func (s *testStore) getInstances(srv info) (instances, error) {
-	var r instances
-
-	for _, i := range s.instances {
-		if reflect.DeepEqual(srv, i.info) {
-			r = append(r, i)
-		}
-	}
-
-	if len(r) == 0 {
+	r, ok := s.instances[srv]
+	if !ok {
 		return nil, newError(errNoInstances, "")
 	}
-
 	return r, nil
 }
 
@@ -105,7 +97,6 @@ func generateInstancesFromInfo(i info) instances {
 
 	for j := 0; j < n; j++ {
 		ins[j] = &instance{
-			info: i,
 			host: "suppenkasper",
 			ip:   net.ParseIP("1.2.3.4"),
 			port: uint16(20000 + j),

--- a/agent/helper_test.go
+++ b/agent/helper_test.go
@@ -21,9 +21,14 @@ func (s *brokenStore) getInstances(srv info) (instances, error) {
 	return nil, newError(errConsulAPI, "could not get instances")
 }
 
+func (s *brokenStore) getServers(zone string) (instances, error) {
+	return nil, newError(errConsulAPI, "could not get servers")
+}
+
 // testStore implements the glimpse.store interface.
 type testStore struct {
 	instances map[info]instances
+	servers   map[string]instances
 }
 
 func (s *testStore) getInstances(srv info) (instances, error) {
@@ -32,6 +37,10 @@ func (s *testStore) getInstances(srv info) (instances, error) {
 		return nil, newError(errNoInstances, "")
 	}
 	return r, nil
+}
+
+func (s *testStore) getServers(zone string) (instances, error) {
+	return s.servers[zone], nil
 }
 
 // testWriter implements the dns.ResponseWriter interface.
@@ -96,7 +105,7 @@ func generateInstancesFromInfo(i info) instances {
 	)
 
 	for j := 0; j < n; j++ {
-		ins[j] = &instance{
+		ins[j] = instance{
 			host: "suppenkasper",
 			ip:   net.ParseIP("1.2.3.4"),
 			port: uint16(20000 + j),

--- a/agent/instrumentation_test.go
+++ b/agent/instrumentation_test.go
@@ -234,7 +234,7 @@ func TestMetricsStore(t *testing.T) {
 			zone:    "tt",
 		}
 		ins = generateInstancesFromInfo(i)
-		s   = newMetricsStore(&testStore{instances: ins})
+		s   = newMetricsStore(&testStore{instances: map[info]instances{i: ins}})
 	)
 
 	sins, err := s.getInstances(i)

--- a/agent/instrumentation_test.go
+++ b/agent/instrumentation_test.go
@@ -224,7 +224,7 @@ func TestDnsMetricsHandler(t *testing.T) {
 	}
 }
 
-func TestMetricsStore(t *testing.T) {
+func TestMetricsStoreGetInstances(t *testing.T) {
 	var (
 		i = info{
 			service: "http",
@@ -243,6 +243,23 @@ func TestMetricsStore(t *testing.T) {
 	}
 
 	if want, got := ins, sins; !reflect.DeepEqual(want, got) {
+		t.Errorf("want %d instances, got %d", len(want), len(got))
+	}
+}
+
+func TestMetricsStoreGetServers(t *testing.T) {
+	var (
+		zone = "tt"
+		srvs = instances{{host: "foo"}}
+		m    = map[string]instances{zone: srvs}
+		s    = newMetricsStore(&testStore{servers: m})
+	)
+
+	ss, err := s.getServers(zone)
+	if err != nil {
+		t.Fatalf("want store to not return an error, got %s", err)
+	}
+	if want, got := srvs, ss; !reflect.DeepEqual(want, got) {
 		t.Errorf("want %d instances, got %d", len(want), len(got))
 	}
 }

--- a/agent/types.go
+++ b/agent/types.go
@@ -27,9 +27,10 @@ var (
 
 type store interface {
 	getInstances(info) (instances, error)
+	getServers(string) (instances, error)
 }
 
-type instances []*instance
+type instances []instance
 
 type instance struct {
 	host string
@@ -51,6 +52,13 @@ type info struct {
 	zone     string
 }
 
+func validateZone(zone string) error {
+	if !rZone.MatchString(zone) {
+		return fmt.Errorf("zone %q is invalid", zone)
+	}
+	return nil
+}
+
 func infoFromAddr(addr string) (info, error) {
 	fields := strings.SplitN(addr, ".", 5)
 
@@ -66,8 +74,8 @@ func infoFromAddr(addr string) (info, error) {
 		service = fields[0]
 	)
 
-	if len(zone) > 1 && !rZone.MatchString(zone) {
-		return info{}, fmt.Errorf("zone %q is invalid", zone)
+	if err := validateZone(zone); err != nil {
+		return info{}, err
 	}
 	if !rField.MatchString(product) {
 		return info{}, fmt.Errorf("product %q is invalid", product)

--- a/agent/types.go
+++ b/agent/types.go
@@ -32,7 +32,6 @@ type store interface {
 type instances []*instance
 
 type instance struct {
-	info info
 	host string
 	ip   net.IP
 	port uint16


### PR DESCRIPTION
In order to support recursive DNS resolution, this change adds support
for NS queries. It's expected that all servers are registered under one
common domain. For example under srv.example.com. Now it'll be possible
to query any of the servers for the responsible name server of
{zone}.srv.example.com.

Please note that doing such a NS query against a normal agent which is
not a server won't return any results.