### PR TITLE
Enable DNS message compression

### DIFF
--- a/agent/dns.go
+++ b/agent/dns.go
@@ -26,6 +26,7 @@ func dnsHandler(store store, zone, domain string) dns.HandlerFunc {
 		)
 
 		res.SetReply(req)
+		res.Compress = true
 
 		if len(req.Question) == 0 {
 			res.SetRcode(req, dns.RcodeFormatError)

--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -180,6 +180,10 @@ func TestDNSHandler(t *testing.T) {
 			t.Errorf("want available recursion %t, got %t", want, got)
 		}
 
+		if want, got := true, r.Compress; want != got {
+			t.Errorf("want message compression %t, got %t", want, got)
+		}
+
 		if want, got := r.Rcode == dns.RcodeSuccess, r.Authoritative; want != got {
 			t.Errorf("want authoritative %t, got %t", want, got)
 		}


### PR DESCRIPTION
Enables message compression to remove the repition of the question in
every answer's resource record.

    # without compression
    dig SRV telemetry.pm.prod.bazooka.db.sd.int.s-cloud.net | grep rcvd
    ;; MSG SIZE  rcvd: 2207

    # with compression
    dig SRV telemetry.pm.prod.bazooka.db.sd.int.s-cloud.net | grep rcvd
    ;; MSG SIZE  rcvd: 1208

This enables SRV lookups with much larger result sets.