### PR TITLE
Simplify error handling

### DIFF
--- a/agent/dns.go
+++ b/agent/dns.go
@@ -42,7 +42,7 @@ func dnsHandler(store store, zone, domain string) dns.HandlerFunc {
 		q = req.Question[0]
 
 		if !strings.HasSuffix(q.Name, domain) {
-			log.Printf("[warning] dns - unknown domain %s (authoritative zone: %s)", q.Name, domain)
+			log.Printf("[warning] DNS - unknown domain %s (authoritative zone: %s)", q.Name, domain)
 			res.SetRcode(req, dns.RcodeNameError)
 			goto respond
 		}
@@ -58,7 +58,7 @@ func dnsHandler(store store, zone, domain string) dns.HandlerFunc {
 		case dns.TypeA, dns.TypeSRV:
 			srv, err = infoFromAddr(addr)
 			if err != nil {
-				log.Printf("[warning] dns - address parsing failed '%s': %s", q.Name, err)
+				log.Printf("[warning] DNS - address parsing failed '%s': %s", q.Name, err)
 				res.SetRcode(req, dns.RcodeNameError)
 				goto respond
 			}
@@ -109,7 +109,7 @@ func dnsHandler(store store, zone, domain string) dns.HandlerFunc {
 	respond:
 		err = w.WriteMsg(res)
 		if err != nil {
-			log.Printf("[error] dns - write msg failed: %s", err)
+			log.Printf("[error] DNS - write msg failed: %s", err)
 		}
 
 		reqInfo := dns.TypeToString[q.Qtype] + " " + q.Name
@@ -118,7 +118,7 @@ func dnsHandler(store store, zone, domain string) dns.HandlerFunc {
 		}
 		// TODO(alx): Put logging in central place for control in different
 		//            environemnts.
-		log.Printf("[info] dns - request: %s response: %s (%d rrs)",
+		log.Printf("[info] DNS - request: %s response: %s (%d rrs)",
 			reqInfo, dns.RcodeToString[res.Rcode], len(res.Answer))
 	}
 }

--- a/agent/instrumentation.go
+++ b/agent/instrumentation.go
@@ -103,14 +103,12 @@ func dnsMetricsHandler(next dns.Handler) dns.HandlerFunc {
 // consulCollector implements the prometheus.Collector interface.
 type consulCollector struct {
 	info    string
-	errc    chan error
 	metrics map[string]prometheus.Gauge
 }
 
-func newConsulCollector(info string, errc chan error) prometheus.Collector {
+func newConsulCollector(info string) prometheus.Collector {
 	return &consulCollector{
 		info:    info,
-		errc:    errc,
 		metrics: map[string]prometheus.Gauge{},
 	}
 }
@@ -118,7 +116,6 @@ func newConsulCollector(info string, errc chan error) prometheus.Collector {
 func (c *consulCollector) Collect(metricc chan<- prometheus.Metric) {
 	err := c.updateMetrics()
 	if err != nil {
-		c.errc <- err
 		return
 	}
 
@@ -131,7 +128,6 @@ func (c *consulCollector) Collect(metricc chan<- prometheus.Metric) {
 func (c *consulCollector) Describe(descc chan<- *prometheus.Desc) {
 	err := c.updateMetrics()
 	if err != nil {
-		c.errc <- err
 		return
 	}
 

--- a/agent/main.go
+++ b/agent/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -91,25 +92,25 @@ func main() {
 	}, errc)
 	go func(addr string, errc chan<- error) {
 		log.Printf("[info] HTTP listening on %s\n", addr)
-		errc <- http.ListenAndServe(addr, nil)
+		err := http.ListenAndServe(addr, nil)
+		errc <- fmt.Errorf("[error] HTTP - server failed: %s", err)
 	}(*httpAddr, errc)
-	go registerConsulCollector(*consulInfo, errc)
 
-	for {
-		select {
-		case err := <-errc:
-			log.Printf("[error] prometheus - collect failed: %s", err)
-		}
+	if *consulInfo != "" {
+		go registerConsulCollector(*consulInfo)
 	}
+
+	log.Fatalln(<-errc)
 }
 
 func runDNSServer(server *dns.Server, errc chan error) {
 	log.Printf("[info] DNS/%s listening on %s\n", server.Net, server.Addr)
-	errc <- server.ListenAndServe()
+	err := server.ListenAndServe()
+	errc <- fmt.Errorf("[error] DNS/%s - server failed: %s", server.Net, err)
 }
 
-func registerConsulCollector(consulInfo string, errc chan error) {
-	c := newConsulCollector(consulInfo, errc)
+func registerConsulCollector(consulInfo string) {
+	c := newConsulCollector(consulInfo)
 
 	for {
 		if err := prometheus.Register(c); err != nil {


### PR DESCRIPTION
This change simplifies the error handling in the following way:

* Any HTTP/DNS server error will immediately cause a program to exit with
  code=1.
* If consul is not running or more correctly if `consul info` or the
  stats parsing returns with an error, glimpse-agent will continue to
  run as it does without this change already. This ensures that other
  metrics will still be collected like DNS requests. Also if the consul HTTP
  interface is reachable requests will be handled without any issue.
  glimpse-agent will continue to try initializing the stats module until
  it succeeds.
* The consul stats parsing can be deactivated by passing -consul.info=""
  now.
* Error messages from the DNS or HTTP servers will be printed correctly
  now.
* Logging output got unified.

---

Examples:

consul agent not running during the first three seconds:

```
glimpse-agent 16:25:43.367179 [info] glimpse-agent starting. v0.3.3
glimpse-agent 16:25:43.367366 [info] DNS/tcp listening on :5959
glimpse-agent 16:25:43.367436 [info] DNS/udp listening on :5959
glimpse-agent 16:25:43.367586 [info] HTTP listening on :5960
glimpse-agent 16:25:43.372658 [error] prometheus - could not register collector (-consul.info=consul info)
glimpse-agent 16:25:44.382231 [error] prometheus - could not register collector (-consul.info=consul info)
glimpse-agent 16:25:45.391224 [error] prometheus - could not register collector (-consul.info=consul info)
glimpse-agent 16:26:35.501953 [info] DNS - request: NS srv.glimpse.io. response: NOERROR (1 rrs)
...
````

DNS port already taken:

```
glimpse-agent 16:45:07.647049 [info] glimpse-agent starting. v0.3.3
glimpse-agent 16:45:07.647477 [info] DNS/tcp listening on :5959
glimpse-agent 16:45:07.647636 [info] DNS/udp listening on :5959
glimpse-agent 16:45:07.647756 [info] HTTP listening on :5960
glimpse-agent 16:45:07.648641 [error] DNS/tcp - server failed: listen tcp :5959: bind: address already in use
```

@soundcloud/iss 