### PR TITLE
Enable profiling endpoint(s)

### DIFF
--- a/agent/main.go
+++ b/agent/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"regexp"


### PR DESCRIPTION
Not much to it. Enables `go tool pprof 'http://somehost:5380/debug/pprof/profile'`