### PR TITLE
Logging improvements

### DIFF
--- a/agent/logging.go
+++ b/agent/logging.go
@@ -33,7 +33,7 @@ func (w *loggingWriter) WriteMsg(res *dns.Msg) error {
 
 	err := w.ResponseWriter.WriteMsg(res)
 	if err != nil {
-		errField = err.Error()
+		errField = " error: " + err.Error()
 	}
 
 	if len(res.Question) > 0 && res.Question[0].Qtype != dns.TypeNone {
@@ -44,7 +44,7 @@ func (w *loggingWriter) WriteMsg(res *dns.Msg) error {
 	}
 
 	w.logger.Printf(
-		"DNS %dms %s %s %s %s %d '%s'",
+		"DNS %dms %s %s %s %s %d%s",
 		time.Since(w.start)/time.Millisecond,
 		w.RemoteAddr().String(),
 		qType,
@@ -71,7 +71,7 @@ func newLoggingStore(logger *log.Logger, next store) store {
 
 func (s *loggingStore) getInstances(i info) (is instances, err error) {
 	defer func(start time.Time) {
-		s.log(time.Since(start), "getInstances", err, i.addr())
+		s.log(time.Since(start), "getInstances", i.addr(), err)
 	}(time.Now())
 
 	return s.next.getInstances(i)
@@ -79,16 +79,16 @@ func (s *loggingStore) getInstances(i info) (is instances, err error) {
 
 func (s *loggingStore) getServers(zone string) (is instances, err error) {
 	defer func(start time.Time) {
-		s.log(time.Since(start), "getServers", err, zone)
+		s.log(time.Since(start), "getServers", zone, err)
 	}(time.Now())
 
 	return s.next.getServers(zone)
 }
 
-func (s *loggingStore) log(took time.Duration, op string, err error, input string) {
+func (s *loggingStore) log(took time.Duration, op, input string, err error) {
 	if err == nil {
 		return
 	}
 
-	s.logger.Printf("STORE %dms %s %s %s", took/time.Millisecond, op, errToLabel(err), input)
+	s.logger.Printf("STORE %dms %s %s error: %s", took/time.Millisecond, op, input, err)
 }

--- a/agent/logging.go
+++ b/agent/logging.go
@@ -44,8 +44,8 @@ func (w *loggingWriter) WriteMsg(res *dns.Msg) error {
 	}
 
 	w.logger.Printf(
-		"DNS %d %s %s %s %s %d '%s'",
-		time.Since(w.start),
+		"DNS %dms %s %s %s %s %d '%s'",
+		time.Since(w.start)/time.Millisecond,
 		w.RemoteAddr().String(),
 		qType,
 		qName,
@@ -90,5 +90,5 @@ func (s *loggingStore) log(took time.Duration, op string, err error, input strin
 		return
 	}
 
-	s.logger.Printf("STORE %d %s %s %s", took, op, errToLabel(err), input)
+	s.logger.Printf("STORE %dms %s %s %s", took/time.Millisecond, op, errToLabel(err), input)
 }

--- a/agent/logging.go
+++ b/agent/logging.go
@@ -27,8 +27,8 @@ type loggingWriter struct {
 func (w *loggingWriter) WriteMsg(res *dns.Msg) error {
 	var (
 		errField = ""
-		reqType  = "empty"
-		reqName  = "empty"
+		qType    = "empty"
+		qName    = "empty"
 	)
 
 	err := w.ResponseWriter.WriteMsg(res)
@@ -39,16 +39,16 @@ func (w *loggingWriter) WriteMsg(res *dns.Msg) error {
 	if len(res.Question) > 0 && res.Question[0].Qtype != dns.TypeNone {
 		q := res.Question[0]
 
-		reqType = dns.TypeToString[q.Qtype]
-		reqName = q.Name
+		qType = dns.TypeToString[q.Qtype]
+		qName = q.Name
 	}
 
 	w.logger.Printf(
 		"DNS %d %s %s %s %s %d '%s'",
 		time.Since(w.start),
 		w.RemoteAddr().String(),
-		reqType,
-		reqName,
+		qType,
+		qName,
 		dns.RcodeToString[res.Rcode],
 		len(res.Answer),
 		errField,

--- a/agent/logging_test.go
+++ b/agent/logging_test.go
@@ -40,7 +40,7 @@ func TestDNSLoggingHandler(t *testing.T) {
 
 	sp := strings.SplitN(strings.Trim(b.String(), "\n"), " ", 10)
 
-	if want, have := 10, len(sp); want != have {
+	if want, have := 9, len(sp); want != have {
 		t.Fatalf("want %d fields, got %d fields", want, have)
 	}
 
@@ -67,10 +67,6 @@ func TestDNSLoggingHandler(t *testing.T) {
 	if want, have := "0", sp[8]; want != have {
 		t.Errorf("want %s, have %s", want, have)
 	}
-
-	if want, have := "''", sp[9]; want != have {
-		t.Errorf("want %#v, have %#v", want, have)
-	}
 }
 
 func TestDNSLoggingHandlerError(t *testing.T) {
@@ -96,7 +92,7 @@ func TestDNSLoggingHandlerError(t *testing.T) {
 
 	sp := strings.SplitN(strings.Trim(b.String(), "\n"), " ", 10)
 
-	if want, have := "'failed write'", sp[9]; want != have {
+	if want, have := "error: failed write", sp[9]; want != have {
 		t.Errorf("want %#v, have %#v", want, have)
 	}
 }
@@ -151,11 +147,11 @@ func TestLoggingStoreError(t *testing.T) {
 		t.Errorf("want %s, have %s", want, have)
 	}
 
-	if want, have := errLabels[errNoInstances], sp[5]; want != have {
+	if want, have := "...nonsense", sp[5]; want != have {
 		t.Errorf("want %s, have %s", want, have)
 	}
 
-	if want, have := "...nonsense", sp[6]; want != have {
+	if want, have := "error:", sp[6]; want != have {
 		t.Errorf("want %s, have %s", want, have)
 	}
 
@@ -176,11 +172,11 @@ func TestLoggingStoreError(t *testing.T) {
 		t.Errorf("want %s, have %s", want, have)
 	}
 
-	if want, have := errLabels[errNoInstances], sp[5]; want != have {
+	if want, have := "zz", sp[5]; want != have {
 		t.Errorf("want %s, have %s", want, have)
 	}
 
-	if want, have := "zz", sp[6]; want != have {
+	if want, have := errNoInstances.Error(), strings.Join(sp[7:], " "); strings.HasPrefix(want, have) {
 		t.Errorf("want %s, have %s", want, have)
 	}
 }


### PR DESCRIPTION
This change aims to make log lines more self-explanatory, easier to read and easier to filter. Most importantly all lines describing an error condition now include the keyword "error" again, allowing for easy filtering with standard posix tools. The other part is to log durations in milliseconds including the unit so that operators have a better chance to understand what that field is about.

@peterbourgon @xla 

```
# before
glimpse-agent 15:34:17.482323 STORE 1595824570 getInstances consulapi telemetry.agent.prod.glimpse.dd
glimpse-agent 15:34:17.482428 DNS 1595952716 127.0.0.1:10989 A telemetry.agent.prod.glimpse.dd.srv.glimpse.io. SERVFAIL 0 ''

# after
glimpse-agent 15:37:03.306621 STORE 7651ms getInstances telemetry.agent.prod.glimpse.dd error: Consul API failed: Get http://foobar:5361/v1/health/service/glimpse?dc=dd&passing=1&stale=&tag=glimpse%3Ajob%3Dagent: dial tcp: lookup foobar: no such host
glimpse-agent 15:37:03.306703 DNS 7651ms 127.0.0.1:60306 A telemetry.agent.prod.glimpse.dd.srv.glimpse.io. SERVFAIL 0
```