### PR TITLE
Handle requests with unknown zone correctly

### DIFF
--- a/agent/acceptance_test.go
+++ b/agent/acceptance_test.go
@@ -138,6 +138,12 @@ func TestAgent(t *testing.T) {
 			net:   "udp",
 			rcode: dns.RcodeNameError,
 		},
+		{
+			query: fqdn(testCase0.srvAddr, "ff", dnsZone),
+			qtype: dns.TypeA,
+			net:   "tcp",
+			rcode: dns.RcodeNameError,
+		},
 	}
 
 	consul, err := runConsul()

--- a/agent/consul.go
+++ b/agent/consul.go
@@ -38,6 +38,9 @@ func (s *consulStore) getInstances(info info) (instances, error) {
 	// the expected response.
 	entries, _, err := s.client.Health().Service(info.product, jobTag, passingOnly, options)
 	if err != nil {
+		if strings.Contains(err.Error(), "No path to datacenter") {
+			return nil, newError(errNoInstances, "unknown zone %s", info.zone)
+		}
 		return nil, newError(errConsulAPI, "%s", err)
 	}
 


### PR DESCRIPTION
So far, when glimpse-agent processes a request for an unknown zone, it
would just log the Consul API error (status code 500) and respond with a
DNS SERVFAIL response.

A SERVFAIL response will cause recursors like unbound to retry the
question a couple of times unnecessarily. The desired behavior is that
clients receive a NXDOMAIN response if the zone is unknown.

With this change, there should be no more `errConsulAPI` happen during
normal operation, allowing to set up alerts if the error rate goes above
zero.

@peterbourgon @xla